### PR TITLE
Change 'Field Office' to 'Resource Center' everywhere, and make clicking office title links work the same as clicking map markers

### DIFF
--- a/googleMaps.js
+++ b/googleMaps.js
@@ -3,7 +3,7 @@ const center = { lat: 41.5, lng: -72.7575 };
 const zoom = 10;
 const locations = [
   {
-    title: 'Bridgeport Field Office',
+    title: 'Bridgeport Resource Center',
     address: '925 Housatonic Avenue',
     city: 'Bridgeport, CT 06606',
     geometry: {
@@ -23,7 +23,7 @@ const locations = [
     place_id: 'ChIJl9gQJYYO6IkRH2NNKPJqnr4'
   },
   {
-    title: 'Danbury Field Office',
+    title: 'Danbury Resource Center',
     address: '342 Main Street',
     city: 'Danbury, CT 06810',
     geometry: {
@@ -43,7 +43,7 @@ const locations = [
     place_id: 'ChIJ5aSEVGT_54kRoNybHkmC-TI'
   },
   {
-    title: 'Greater Hartford Field Office',
+    title: 'Greater Hartford Resource Center',
     address: '20 Meadow Road',
     city: 'Windsor, CT 06095',
     geometry: {
@@ -63,7 +63,7 @@ const locations = [
     place_id: 'ChIJ9Z6kp1RU5okRfgyY545LKwA'
   },
   {
-    title: 'Manchester Field Office',
+    title: 'Manchester Resource Center',
     address: '699 East Middle Turnpike',
     city: 'Manchester, CT 06040',
     geometry: {
@@ -83,7 +83,7 @@ const locations = [
     place_id: 'ChIJjdigBkxY5okRgL-oM8za1Ww'
   },
   {
-    title: 'Middletown Field Office',
+    title: 'Middletown Resource Center',
     address: '2081 South Main Street, Suite B',
     city: 'Middletown, CT 06457',
     geometry: {
@@ -103,7 +103,7 @@ const locations = [
     place_id: 'ChIJ26GEiGlK5okRTPXMAXujvnw'
   },
   {
-    title: 'New Britain Field Office',
+    title: 'New Britain Resource Center',
     address: '30 Christian Lane',
     city: 'New Britain, CT 06051-4152',
     geometry: {
@@ -123,7 +123,7 @@ const locations = [
     place_id: 'ChIJIRWGEAyz54kROxZ8lFLUmS0'
   },
   {
-    title: 'New Haven Field Office',
+    title: 'New Haven Resource Center',
     address: '50 Humphrey Street',
     city: 'New Haven, CT 06513',
     geometry: {
@@ -143,7 +143,7 @@ const locations = [
     place_id: 'ChIJGY8XP9rZ54kRSYzf2RrCyM0'
   },
   {
-    title: 'Norwich Field Office',
+    title: 'Norwich Resource Center',
     address: '401 West Thames Street',
     city: 'Norwich, CT 06360',
     geometry: {
@@ -163,7 +163,7 @@ const locations = [
     place_id: 'ChIJq7_XuEpy5okR04gArAvdS20'
   },
   {
-    title: 'Torrington Field Office',
+    title: 'Torrington Resource Center',
     address: '62 Commercial Boulevard',
     city: 'Torrington, CT 06790',
     geometry: {
@@ -183,7 +183,7 @@ const locations = [
     place_id: 'ChIJlb_mKbqY54kR564RqRpzPrA'
   },
   {
-    title: 'Stamford Field Office',
+    title: 'Stamford Resource Center',
     address: '1642 Bedford Street',
     city: 'Stamford, CT 06905',
     geometry: {
@@ -203,7 +203,7 @@ const locations = [
     place_id: 'ChIJ7z4tUeuhwokRVeY-o2FzoDs'
   },
   {
-    title: 'Waterbury Field Office',
+    title: 'Waterbury Resource Center',
     address: '249 Thomaston Avenue',
     city: 'Waterbury, CT 06702',
     geometry: {
@@ -223,7 +223,7 @@ const locations = [
     place_id: 'ChIJVRErv03A54kR_PeaRUf5tKM'
   },
   {
-    title: 'Willimantic Field Office',
+    title: 'Willimantic Resource Center',
     address: '1320 Main Street / Tyler Square',
     city: 'Willimantic, CT 06226',
     geometry: {
@@ -421,6 +421,11 @@ async function initMap() {
     });
 
     marker.addListener('click', () => {
+      handleMarkerClick(location, marker);
+    });
+
+    const title_link = document.getElementById('office-title-link-' + location.place_id);
+    title_link.addEventListener('click', () => {
       handleMarkerClick(location, marker);
     });
 

--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
                   <span class="office-label">1</span>
                 </div>
                 <div>
-                  <a href="/" class="office-title-link">
-                    <div class="office-title">Bridgeport Field Office</div>
+                  <a href="#" class="office-title-link" id="office-title-link-ChIJl9gQJYYO6IkRH2NNKPJqnr4">
+                    <div class="office-title">Bridgeport Resource Center</div>
                   </a>
                   <div class="office-address">925 Housatonic Avenue</div>
                   <div class="office-address">Bridgeport, CT 06606</div>
@@ -46,8 +46,8 @@
                   <span class="office-label">2</span>
                 </div>
                 <div>
-                  <a href="/" class="office-title-link">
-                    <div class="office-title">Danbury Field Office</div>
+                  <a href="#" class="office-title-link" id="office-title-link-ChIJ5aSEVGT_54kRoNybHkmC-TI">
+                    <div class="office-title">Danbury Resource Center</div>
                   </a>
                   <div class="office-address">342 Main Street</div>
                   <div class="office-address">Danbury, CT 06810</div>
@@ -73,9 +73,9 @@
                   <span class="office-label">3</span>
                 </div>
                 <div>
-                  <a href="/" class="office-title-link">
+                  <a href="#" class="office-title-link" id="office-title-link-ChIJ9Z6kp1RU5okRfgyY545LKwA">
                     <div class="office-title">
-                      Greater Hartford Field Office
+                      Greater Hartford Resource Center
                     </div>
                   </a>
                   <div class="office-address">20 Meadow Road</div>
@@ -102,8 +102,8 @@
                   <span class="office-label">4</span>
                 </div>
                 <div>
-                  <a href="/" class="office-title-link">
-                    <div class="office-title">Manchester Field Office</div>
+                  <a href="#" class="office-title-link" id="office-title-link-ChIJjdigBkxY5okRgL-oM8za1Ww">
+                    <div class="office-title">Manchester Resource Center</div>
                   </a>
                   <div class="office-address">699 East Middle Turnpike</div>
                   <div class="office-address">Manchester, CT 06040</div>
@@ -129,8 +129,8 @@
                   <span class="office-label">5</span>
                 </div>
                 <div>
-                  <a href="/" class="office-title-link">
-                    <div class="office-title">Middletown Field Office</div>
+                  <a href="#" class="office-title-link" id="office-title-link-ChIJ26GEiGlK5okRTPXMAXujvnw">
+                    <div class="office-title">Middletown Resource Center</div>
                   </a>
                   <div class="office-address">
                     2081 South Main Street, Suite B
@@ -158,8 +158,8 @@
                   <span class="office-label">6</span>
                 </div>
                 <div>
-                  <a href="/" class="office-title-link">
-                    <div class="office-title">New Britain Field Office</div>
+                  <a href="#" class="office-title-link" id="office-title-link-ChIJIRWGEAyz54kROxZ8lFLUmS0">
+                    <div class="office-title">New Britain Resource Center</div>
                   </a>
                   <div class="office-address">30 Christian Lane</div>
                   <div class="office-address">New Britain, CT 06051-4152</div>
@@ -185,8 +185,8 @@
                   <span class="office-label">7</span>
                 </div>
                 <div>
-                  <a href="/" class="office-title-link">
-                    <div class="office-title">New Haven Field Office</div>
+                  <a href="#" class="office-title-link" id="office-title-link-ChIJGY8XP9rZ54kRSYzf2RrCyM0">
+                    <div class="office-title">New Haven Resource Center</div>
                   </a>
                   <div class="office-address">50 Humphrey Street</div>
                   <div class="office-address">New Haven, CT 06513</div>
@@ -212,8 +212,8 @@
                   <span class="office-label">8</span>
                 </div>
                 <div>
-                  <a href="/" class="office-title-link">
-                    <div class="office-title">Norwich Field Office</div>
+                  <a href="#" class="office-title-link" id="office-title-link-ChIJq7_XuEpy5okR04gArAvdS20">
+                    <div class="office-title">Norwich Resource Center</div>
                   </a>
                   <div class="office-address">401 West Thames Street</div>
                   <div class="office-address">Norwich, CT 06360</div>
@@ -239,8 +239,8 @@
                   <span class="office-label">9</span>
                 </div>
                 <div>
-                  <a href="/" class="office-title-link">
-                    <div class="office-title">Torrington Field Office</div>
+                  <a href="#" class="office-title-link" id="office-title-link-ChIJlb_mKbqY54kR564RqRpzPrA">
+                    <div class="office-title">Torrington Resource Center</div>
                   </a>
                   <div class="office-address">62 Commercial Boulevard</div>
                   <div class="office-address">Torrington, CT 06790</div>
@@ -266,8 +266,8 @@
                   <span class="office-label">10</span>
                 </div>
                 <div>
-                  <a href="/" class="office-title-link">
-                    <div class="office-title">Stamford Field Office</div>
+                  <a href="#" class="office-title-link" id="office-title-link-ChIJ7z4tUeuhwokRVeY-o2FzoDs">
+                    <div class="office-title">Stamford Resource Center</div>
                   </a>
                   <div class="office-address">1642 Bedford Street</div>
                   <div class="office-address">Stamford, CT 06905</div>
@@ -293,8 +293,8 @@
                   <span class="office-label">11</span>
                 </div>
                 <div>
-                  <a href="/" class="office-title-link">
-                    <div class="office-title">Waterbury Field Office</div>
+                  <a href="#" class="office-title-link" id="office-title-link-ChIJVRErv03A54kR_PeaRUf5tKM">
+                    <div class="office-title">Waterbury Resource Center</div>
                   </a>
                   <div class="office-address">249 Thomaston Avenue</div>
                   <div class="office-address">Waterbury, CT 06702</div>
@@ -320,8 +320,8 @@
                   <span class="office-label">12</span>
                 </div>
                 <div>
-                  <a href="/" class="office-title-link">
-                    <div class="office-title">Willimantic Field Office</div>
+                  <a href="#" class="office-title-link" id="office-title-link-ChIJgUOPQuRj5okRts5aRoLAlPc">
+                    <div class="office-title">Willimantic Resource Center</div>
                   </a>
                   <div class="office-address">
                     1320 Main Street / Tyler Square


### PR DESCRIPTION
Hi,

Dan asked me if I could update the "Field Office" text in the titles and map marker labels to "Resource Center". He also mentioned wanting to be able to click the office titles to show the marker labels, so I took a crack at that as well. Hopefully he called you to let you know a change was coming - he was also interested in figuring out how to deploy the change, if it looks good, though I know DSS linking to your Vercel deployment should not be the long-term plan.

Cheers,
Mike Rotondo at Code for America